### PR TITLE
계정분산처리, 클라우드 작업삭제

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -29,6 +29,7 @@ class Logic(object):
         # Direct
         'default_username' : '',
         'default_folder_id' : '',
+        'upload_folder_list' : '',
         
         # RSS
         'request_http_start_link' : 'False',
@@ -37,6 +38,7 @@ class Logic(object):
         'tracer_max_day' : '3',
         'last_list_option_rss' : '',
         'remove_history_on_web' : 'False',
+        'remove_cloud_history_on_web' : 'False',
 
         # cache
         'cache_save_type_list' : '',
@@ -225,6 +227,19 @@ class Logic(object):
                 connection.close()
                 ModelSetting.set('db_version', '6')
                 db.session.flush()
+            
+            if ModelSetting.get('db_version') == '6':
+                import sqlite3
+                db_file = os.path.join(path_app_root, 'data', 'db', '%s.db' % package_name)
+                connection = sqlite3.connect(db_file)
+                cursor = connection.cursor()
+                try: cursor.execute('ALTER TABLE %s_job ADD username2 VARCHAR' % (package_name))
+                except: pass
+                connection.close()
+                ModelSetting.set('db_version', '7')
+                db.session.flush()
+            
+            
         except Exception as e:
             logger.error('Exception:%s', e)
             logger.error(traceback.format_exc())

--- a/model.py
+++ b/model.py
@@ -217,6 +217,10 @@ class ModelOffcloud2Job(db.Model):
     rss_regex = db.Column(db.String) # \n 구분  블랙리스트이고 비어있으면 다 받음. 블랙리스트 매칭되면 안 받음. 
     # 화이트리스트이고 비어있으면 안 받음
     # 화이트리스트고 매칭되면 받음
+    
+    # db_version 7
+    username2 = db.Column(db.String) # 계정 분산 처리용
+    
 
     def __init__(self):
         self.created_time = datetime.datetime.now()
@@ -244,6 +248,7 @@ class ModelOffcloud2Job(db.Model):
             job.rss_mode = (req.form['job_rss_mode'] == 'True')
             job.rss_regex = req.form['job_rss_regex']
             job.username = req.form['job_username']
+            job.username2 = req.form['job_username2']
             job.folderid = req.form['job_folderid']
             job.mode = req.form['job_mode']
             job.cache_confirm_day = int(req.form['job_cache_confirm_day'])

--- a/templates/offcloud2_rss_job.html
+++ b/templates/offcloud2_rss_job.html
@@ -28,6 +28,7 @@
   {{ macros.setting_checkbox('job_rss_mode', 'RSS 매칭 모드', desc=['On : 화이트리스트 모드, Off : 블랙리스트 모드']) }}
   {{ macros.setting_input_textarea('job_rss_regex', 'RSS 매칭 정규식', row='5', desc=['화이트리스트 and 정규식 없음 : 전체 추가되지 않음', '화이트리스트 and 정규식 매칭 : 매칭시 추가', '블랙리스트 and 정규식 없음 : 모두 받음', '블랙리스트 and 정규식 매칭 : 매칭된 피드만 제외하고 모두 추가', '구분자 엔터']) }}
   {{ macros.setting_select_empty('job_username', '계정', col='6') }}
+  {{ macros.setting_input_textarea('job_username2', '계정 분산', desc=['https://offcloud.com/#/account에서 Remote accounts에 등록한 username을 입력' , 'Enter로 구분. 다운로드 1건 마다 각계정이 순서대로 사용됨' , '비워두면 [계정]에서 선택된 한개의 계정만 사용'], row='5') }}
   {{ macros.setting_input_text('job_folderid', 'Folder ID') }}
   {{ macros.setting_radio('job_mode', '다운로드 모드', ['Cache만 받기', '전체 받기', 'Cache 확인만']) }}
   {{ macros.setting_input_int('job_cache_confirm_day', 'Cache 확인 기간', desc='day 단위') }}
@@ -83,6 +84,7 @@ function make_account_select(job_username) {
 $("#job_save_btn").click(function(e) {
   e.preventDefault();
   var formData = get_formdata('#job_form');
+  console.log(formData)
   $.ajax({
     url: '/'+package_name+'/ajax/save_job',
     type: "POST", 
@@ -151,6 +153,7 @@ $("body").on('click', '#add_job_btn', function(e){
 
   make_account_select('');
   //document.getElementById("job_username").value = ''
+  document.getElementById("job_username2").value = ''
   document.getElementById("job_folderid").value = ''
   document.getElementById("job_cache_confirm_day").value = 7
   document.getElementById("job_remove_btn").disabled = true;
@@ -183,6 +186,7 @@ $("body").on('click', '#job_setting_btn', function(e){
       }
       document.getElementById("job_rss_regex").value = current_data.jobs[i].rss_regex;
       make_account_select(current_data.jobs[i].username);
+      document.getElementById("job_username2").value = current_data.jobs[i].username2;
       document.getElementById("job_folderid").value = current_data.jobs[i].folderid;
       document.getElementById("job_cache_confirm_day").value = current_data.jobs[i].cache_confirm_day;
       document.getElementById("job_remove_btn").disabled = false;

--- a/templates/offcloud2_rss_setting.html
+++ b/templates/offcloud2_rss_setting.html
@@ -16,8 +16,8 @@
       {{ macros.setting_checkbox('auto_start_rss', '시작시 자동실행', value=arg['auto_start_rss'], desc='On : 시작시 자동으로 스케쥴러에 등록됩니다.') }}
       {{ macros.setting_checkbox('request_http_start_link', 'http 링크 리모트 추가', value=arg['request_http_start_link'], desc=['On : 마그넷이 아닌 http로 시작하고 =.torrent 끝나지 않는 링크도 다운로드 요청합니다.', '링크가 토렌트 파일인 경우 =.torrent로 끝나도록 해야합니다.', '자막 파일을 같이 받을 경우 유용.']) }}
       {{ macros.setting_input_int('tracer_max_day', '추적 기간', value=arg['tracer_max_day'], desc=['days', '']) }}
-      {{ macros.setting_checkbox('remove_history_on_web', '완료시 웹에서 Remote 목록 삭제', value=arg['remove_history_on_web'], desc=None) }}
-      {{ macros.setting_checkbox('remove_cloud_history_on_web', '완료시 웹에서 Cloud 목록 삭제', value=arg['remove_cloud_history_on_web'], desc=None) }}
+      {{ macros.setting_checkbox('remove_history_on_web', '완료시 웹에서 Remote 작업 삭제', value=arg['remove_history_on_web'], desc=None) }}
+      {{ macros.setting_checkbox('remove_cloud_history_on_web', '완료시 웹에서 Cloud 작업 삭제', value=arg['remove_cloud_history_on_web'], desc=None) }}
       
 
 

--- a/templates/offcloud2_rss_setting.html
+++ b/templates/offcloud2_rss_setting.html
@@ -16,7 +16,8 @@
       {{ macros.setting_checkbox('auto_start_rss', '시작시 자동실행', value=arg['auto_start_rss'], desc='On : 시작시 자동으로 스케쥴러에 등록됩니다.') }}
       {{ macros.setting_checkbox('request_http_start_link', 'http 링크 리모트 추가', value=arg['request_http_start_link'], desc=['On : 마그넷이 아닌 http로 시작하고 =.torrent 끝나지 않는 링크도 다운로드 요청합니다.', '링크가 토렌트 파일인 경우 =.torrent로 끝나도록 해야합니다.', '자막 파일을 같이 받을 경우 유용.']) }}
       {{ macros.setting_input_int('tracer_max_day', '추적 기간', value=arg['tracer_max_day'], desc=['days', '']) }}
-      {{ macros.setting_checkbox('remove_history_on_web', '완료시 웹에서 목록 삭제', value=arg['remove_history_on_web'], desc=None) }}
+      {{ macros.setting_checkbox('remove_history_on_web', '완료시 웹에서 Remote 목록 삭제', value=arg['remove_history_on_web'], desc=None) }}
+      {{ macros.setting_checkbox('remove_cloud_history_on_web', '완료시 웹에서 Cloud 목록 삭제', value=arg['remove_cloud_history_on_web'], desc=None) }}
       
 
 


### PR DESCRIPTION
1
offcloud 사용시 구글드라이브 계정의 750g 리미트 걸리는 걸 방지 하기 위해
분산처리 기능을 넣었습니다.

DB에 username2 라는 컬럼을 추가했고 여기에 등록된 값이 있으면 라운드로빈 방식으로 선택해서 사용합니다.
소주님이 만들어두신 것을 보고
DB버전을 제가 추가 했는데 부적절하거나 문제 있다면 말씀해주세요.

2
기존에 리모트 히스토리 삭제 기능처럼 offcloud의 클라우드로 받은 것도 삭제할 수 있는 기능을 넣었습니다. 

3
이제 안정적으로 동작하는 거 같아서 그전에 제가 추가했던 기능을 추적하기 위한 Debug용 로그들을 많이 정리 했습니다. 